### PR TITLE
Support for overriding the marketing number

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -28,6 +28,7 @@ public class XCodeBuilder extends Builder {
     private Boolean buildIpa;
     private Boolean cleanBeforeBuild;
     private Boolean updateBuildNumber;
+    private String overrideMarketingNumber;
     private String configuration = "Release";
     private String target;
     private String sdk;
@@ -36,13 +37,14 @@ public class XCodeBuilder extends Builder {
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean updateBuildNumber, String configuration, String target, String sdk,
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean updateBuildNumber, String overrideMarketingNumber, String configuration, String target, String sdk,
             String xcodeProjectPath, String xcodeProjectFile) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
         this.cleanBeforeBuild = cleanBeforeBuild;
         this.updateBuildNumber = updateBuildNumber;
+        this.overrideMarketingNumber = overrideMarketingNumber;
         this.configuration = configuration;
         this.xcodeProjectPath = xcodeProjectPath;
         this.xcodeProjectFile = xcodeProjectFile;
@@ -70,6 +72,10 @@ public class XCodeBuilder extends Builder {
 
     public Boolean getUpdateBuildNumber() {
         return updateBuildNumber;
+    }
+
+    public String getOverrideMarketingNumber() {
+        return overrideMarketingNumber;
     }
 
     public String getXcodeProjectPath() {
@@ -136,6 +142,15 @@ public class XCodeBuilder extends Builder {
 //            // only use this version number if we found it
 //            if(returnCode==0)
 //                artifactVersion = output.toString().trim();
+        }
+        
+        if( false == StringUtils.isEmpty(overrideMarketingNumber) ) {
+            listener.getLogger().println("Updating marketing version to " + overrideMarketingNumber);
+            
+            returnCode = launcher.launch().envs(envs).cmds(getDescriptor().agvtoolPath(), "new-marketing-version", overrideMarketingNumber ).stdout(listener).pwd(projectRoot).join();
+            if(returnCode>0) {
+                listener.fatalError("Could not set marketing version to " + overrideMarketingNumber);
+            }
         }
 
         // Clean build directories

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -39,6 +39,12 @@
       help="/plugin/xcode/help-updateBuildNumber.html">
         <f:checkbox name="xcode.updateBuildNumber" checked="${instance.updateBuildNumber}" />
     </f:entry>
+    
+	<f:entry title="New Marketing number" field="overrideMarketingNumber"
+	  description="Leave blank to use projects marketing number."
+	  help="/plugin/xcode/help-updateMarketingNumber.html">
+	  <f:textbox name="xcode.overrideMarketingNumber" value="${instance.overrideMarketingNumber}" />
+	</f:entry>
 
     <f:entry title="Clean before build?" field="cleanBeforeBuild"
       help="/plugin/xcode/help-cleanBeforeBuild.html">

--- a/src/main/webapp/help-updateMarketingNumber.html
+++ b/src/main/webapp/help-updateMarketingNumber.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    This will set the CFBundleShortVersionString to the specified string.
+  </p>
+</div>


### PR DESCRIPTION
This adds a simple field, that will override the projects default marketing number with the content of the field using agvtool. If there isn't anything in the field, then the the marketing number will stay the same. I use marketing number here in the same sense that Apple uses it. This value can be any string. A number is not actually necessary.
